### PR TITLE
Fail on error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem "test-kitchen"
+gem "kitchen-vagrant"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-# anaconda-cookbook-cookbook
+# conda cookbook
 
-TODO: Enter the cookbook description here.
+This cookbook installs conda via the [miniconda installer](https://conda.io/miniconda.html) and lets you set up / update environments.
 
-## Supported Platforms
-
-TODO: List your supported platforms.
 
 ## Attributes
 
@@ -16,27 +13,41 @@ TODO: List your supported platforms.
     <th>Default</th>
   </tr>
   <tr>
-    <td><tt>['anaconda-cookbook']['bacon']</tt></td>
-    <td>Boolean</td>
-    <td>whether to include bacon</td>
-    <td><tt>true</tt></td>
+    <td><tt>['conda']['path']</tt></td>
+    <td>/path/to/where/you/want</td>
+    <td>install directory for all conda files</td>
+    <td><tt>/opt/conda</tt></td>
   </tr>
 </table>
 
 ## Usage
 
-### anaconda-cookbook::default
+### conda::default
 
-Include `anaconda-cookbook` in your node's `run_list`:
+Include `conda` in your node's `run_list`:
 
 ```json
 {
   "run_list": [
-    "recipe[anaconda-cookbook::default]"
+    "recipe[conda::default]"
   ]
 }
 ```
 
-## License and Authors
+This will install conda to the specified path.
 
-Author:: YOUR_NAME (<YOUR_EMAIL>)
+### conda\_environment resource
+To install environments, you can use the `conda_environment` resource in
+another recipe: 
+```ruby
+conda_environment "new_env" do
+  path Pathname.new("/root/environment.yml")
+  action :create
+end
+```
+`path` attribute points to the location of the `environment.yml` file.
+Actions are one of:
+
+- `:create` (for a new environment)
+- `:upgrade` (for environments that already exist)
+-  `:delete` (to delete an environment)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# anaconda-cookbook-cookbook
+
+TODO: Enter the cookbook description here.
+
+## Supported Platforms
+
+TODO: List your supported platforms.
+
+## Attributes
+
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['anaconda-cookbook']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+## Usage
+
+### anaconda-cookbook::default
+
+Include `anaconda-cookbook` in your node's `run_list`:
+
+```json
+{
+  "run_list": [
+    "recipe[anaconda-cookbook::default]"
+  ]
+}
+```
+
+## License and Authors
+
+Author:: YOUR_NAME (<YOUR_EMAIL>)

--- a/Thorfile
+++ b/Thorfile
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+require 'bundler'
+require 'bundler/setup'
+require 'berkshelf/thor'
+
+begin
+  require 'kitchen/thor_tasks'
+  Kitchen::ThorTasks.new
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,90 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.require_version '>= 1.5.0'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  config.vm.hostname = 'anaconda-cookbook-berkshelf'
+
+  # Set the version of chef to install using the vagrant-omnibus plugin
+  # NOTE: You will need to install the vagrant-omnibus plugin:
+  #
+  #   $ vagrant plugin install vagrant-omnibus
+  #
+  if Vagrant.has_plugin?("vagrant-omnibus")
+    config.omnibus.chef_version = 'latest'
+  end
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  # If this value is a shorthand to a box in Vagrant Cloud then
+  # config.vm.box_url doesn't need to be specified.
+  config.vm.box = 'chef/ubuntu-14.04'
+
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  config.vm.network :private_network, type: 'dhcp'
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # The path to the Berksfile to use with Vagrant Berkshelf
+  # config.berkshelf.berksfile_path = "./Berksfile"
+
+  # Enabling the Berkshelf plugin. To enable this globally, add this configuration
+  # option to your ~/.vagrant.d/Vagrantfile file
+  config.berkshelf.enabled = true
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to exclusively install and copy to Vagrant's shelf.
+  # config.berkshelf.only = []
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to skip installing and copying to Vagrant's shelf.
+  # config.berkshelf.except = []
+
+  config.vm.provision :chef_solo do |chef|
+    chef.json = {
+      mysql: {
+        server_root_password: 'rootpass',
+        server_debian_password: 'debpass',
+        server_repl_password: 'replpass'
+      }
+    }
+
+    chef.run_list = [
+      'recipe[anaconda-cookbook::default]'
+    ]
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   # If this value is a shorthand to a box in Vagrant Cloud then
   # config.vm.box_url doesn't need to be specified.
-  config.vm.box = 'chef/ubuntu-14.04'
+  config.vm.box = 'bento/ubuntu-14.04'
 
 
   # Assign this VM to a host-only network IP, allowing you to access it
@@ -84,7 +84,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }
 
     chef.run_list = [
-      'recipe[anaconda-cookbook::default]'
+      'recipe[conda::default]',
+      'recipe[conda::basic_env]'
     ]
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,2 @@
+default["conda"] = {}
+default["conda"]["path"] = "/opt/conda"

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,94 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/files/default/environment.yml
+++ b/files/default/environment.yml
@@ -1,0 +1,15 @@
+#########################################################
+#
+# Warning: Add dependencies by hand one entry at a time.
+# Do not use `conda list --export` or `pip freeze`
+#
+#########################################################
+
+name: basic_sci
+channels:
+- pkgw  # for OSX py2cairo=1.10.0
+dependencies:
+- numpy
+- pip:
+  - jupyter-client==5.0.0
+  - jupyter-core==4.3.0

--- a/providers/environment.rb
+++ b/providers/environment.rb
@@ -29,7 +29,13 @@ action :delete do
 end
 
 action :upgrade do
+    n = @new_resource.name
+    p = @new_resource.path
     # Bug workaround for https://github.com/conda/conda/issues/1420
-    `#{conda} install --name #{@new_resource.name} toolz=0.6 --yes`
-    `#{conda} env update --name #{@new_resource.name} --file #{@new_resource.path}`
+    bash 'install toolz' do
+      code "#{conda} install --name #{n} toolz=0.6 --yes"
+    end
+    bash 'update conda' do
+      code "#{conda} env update --name #{n} --file #{p}"
+    end
 end

--- a/recipes/basic_env.rb
+++ b/recipes/basic_env.rb
@@ -1,0 +1,12 @@
+# Installs an environment called basic_sci that has numpy and jupyter
+cookbook_file "/root/environment.yml" do
+  source "environment.yml"
+  owner "root"
+  group "root"
+  mode "755"
+end
+
+anaconda_environment "root" do
+  path "/root/environment.yml"
+  action :upgrade
+end

--- a/recipes/basic_env.rb
+++ b/recipes/basic_env.rb
@@ -6,7 +6,7 @@ cookbook_file "/root/environment.yml" do
   mode "755"
 end
 
-anaconda_environment "root" do
-  path "/root/environment.yml"
+conda_environment "root" do
+  path Pathname.new("/root/environment.yml")
   action :upgrade
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,7 +12,7 @@ end
 bash "install_miniconda" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
-      /bin/bash Miniconda.sh -b -p /opt/conda
+      /bin/bash Miniconda.sh -b -p #{node["conda"]["path"]}
   EOH
   not_if do ::File.exists? "/opt/conda" end
 end


### PR DESCRIPTION
Currently, update commands that fail don't cause the chef run to fail. This is undesirable.

To fix, we plug into the chef `bash` resource.

This PR also adds in some basic infrastructure for a development workflow / testing, and a README for ease-of-use.