### PR TITLE
Update conda and conda-env immediately after install

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,6 +13,7 @@ bash "install_miniconda" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
       /bin/bash Miniconda.sh -b -p #{node["conda"]["path"]}
+      /opt/conda/bin/conda update -y conda conda-env
   EOH
   not_if do ::File.exists? "/opt/conda" end
 end


### PR DESCRIPTION
I think this will solve the problem of the datacourse-image builds failing over the past week.  There's a test build running here: https://ci.thedataincubator.com/job/datacourse/763/.  If that succeeds, then I think we should merge this in.